### PR TITLE
fix dismount issue during sccm osd due to case difference in paths

### DIFF
--- a/AppDeployToolkit/PSADT.WIMFile/WIMFileExtension.ps1
+++ b/AppDeployToolkit/PSADT.WIMFile/WIMFileExtension.ps1
@@ -944,7 +944,7 @@ Function Dismount-WIMFile {
 		if (Test-Path -Path $DismountPath -ErrorAction SilentlyContinue) {
 
 			#  Check if there is a mounted wim file
-			if ($IsAdmin) { $MountedImage = Get-WindowsImage -Mounted | Where-Object { [IO.Path]::GetFullPath($_.Path).StartsWith($DismountPath.DirectoryName) } }
+			if ($IsAdmin) { $MountedImage = Get-WindowsImage -Mounted | Where-Object { [IO.Path]::GetFullPath($_.Path).StartsWith($DismountPath.DirectoryName,'CurrentCultureIgnoreCase') } }
 			if ($MountedImage) {
 				[IO.FileInfo]$ImagePath = $MountedImage.ImagePath
 				try {


### PR DESCRIPTION
found an issue during an install using the PSADT.WimFile extension during a SCCM OSD install,

The path is to the SCCM cache folder, and the windows folder is upper case in the Get-WindowsImage cmdlet but lower case in the $DismountPath.DirectoryName so the wim file is not unmounted and generates errors trying to delete the mount path.

adding ,'CurrentCultureIgnoreCase' to the StartsWith() function will ignore the case mis-match, which on windows is no issue at all anyway.